### PR TITLE
Makefile.PL: fix typo s/File::Stat/File::stat/

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ requires 'Data::Stream::Bulk' => '0';
 requires 'DateTime::Format::HTTP' => '0.39';
 requires 'Digest::MD5' => '0';
 requires 'Digest::MD5::File' => '0';
-requires 'File::stat';
+requires 'File::stat' => '1.0';
 requires 'File::Slurp' => '0';
 requires 'JSON::Any' => '1.29';
 requires 'LWP' => '0';


### PR DESCRIPTION
`File::stat` is a core module while `File::Stat` is from CPAN. Both conflict on case-insensitive filesystems.
The one used here is `File::stat`.
