### PR TITLE
Rackspace CDN lets you set headers on objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Revision history for Perl module WebService::Rackspace::CloudFiles:
 
+    - Add support for Rackspace Headers (Luke Closs)
+      https://www.rackspace.com/blog/thanks-for-your-feedback-cloud-files-supports-12-new-headers/
     - Reverted: Fixed test concerning cdn. This actually didn't fix it at all
 
 1.07 Mon Feb 21 09:17:00 GMT+2 2012

--- a/lib/WebService/Rackspace/CloudFiles/Object.pm
+++ b/lib/WebService/Rackspace/CloudFiles/Object.pm
@@ -249,6 +249,22 @@ sub put_filename {
     confess 'Unknown error'         unless $response->is_success;
 }
 
+my %Supported_headers = (
+    map { $_ => 1 }
+    'Content-Encoding',
+    'Content-Disposition',
+    'X-Object-Manifest',
+    'Access-Control-Allow-Origin',
+    'Access-Control-Allow-Credentials',
+    'Access-Control-Expose-Headers',
+    'Access-Control-Max-Age',
+    'Access-Control-Allow-Methods',
+    'Access-Control-Allow-Headers',
+    'Origin',
+    'Access-Control-Request-Method',
+    'Access-Control-Request-Headers',
+);
+
 sub _prepare_headers {
     my ($self, $etag, $size) = @_;
     my $headers = HTTP::Headers->new();
@@ -260,7 +276,9 @@ sub _prepare_headers {
     
     my $header_field;
     foreach my $key (keys %{$self->object_metadata}) {
-        $header_field = 'X-Object-Meta-' . $key;
+        $header_field = $key;
+        $header_field = 'X-Object-Meta-' . $header_field
+            unless $Supported_headers{$header_field};
         # make _'s -'s for header sending.
         $header_field =~ s/_/-/g;
         

--- a/t/simple.t
+++ b/t/simple.t
@@ -42,7 +42,11 @@ isa_ok( $one->container,  'WebService::Rackspace::CloudFiles::Container' );
 is( $one->container->name, 'testing', 'container name is testing' );
 is( $one->name,            'one.txt', 'object name is one.txt' );
 
-$one->object_metadata({ description => 'this is a description', useful_number => 17 });
+$one->object_metadata({
+        description => 'this is a description',
+        useful_number => 17,
+        'Access-Control-Allow-Origin' => '*',
+    });
 
 $one->put('this is one');
 
@@ -101,8 +105,9 @@ ok($one->cdn_ssl_url, 'CDN HTTPS URL for object');
 my $ua = LWP::UserAgent->new;
 my $res = $ua->head($one->cdn_url);
 ok($res->is_success, 'Requesting CDN HTTP URL');
+my $h = $res->header('Access-Control-Allow-Origin');
+is($h, '*', 'CORS header exists correctly');
 
-#not purging in these tests because the $one->delete call will fail
 #ok($one->purge_cdn, 'Purging CDN Object');
 
 $one->delete;


### PR DESCRIPTION
Rackspace lets you set CORS (and other) HTTP headers on files served from the CDN.

This patch does not escape these headers, so that they can pass through to the CDN correctly.
