### PR TITLE
Fix a POD link

### DIFF
--- a/lib/WebService/Rackspace/CloudFiles/Container.pm
+++ b/lib/WebService/Rackspace/CloudFiles/Container.pm
@@ -259,7 +259,7 @@ prefix:
 
 =head2 object
 
-This returns a <WebService::Rackspace::CloudFiles::Object> representing
+This returns a L<WebService::Rackspace::CloudFiles::Object> representing
 an object.
 
   my $xxx = $container->object( name => 'XXX' );


### PR DESCRIPTION
Missing an L<> in the POD link for the object method on Container
